### PR TITLE
add upgrade compatibility

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@ dependencies {
     api("com.github.GTNewHorizons:Irontanks:1.4.1:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.38-GTNH:dev")
 
-    implementation("com.github.GTNewHorizons:Railcraft:9.16.13") {
+    implementation("com.github.GTNewHorizons:Railcraft:9.16.16-pre:dev") {
         transitive = false
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api("com.github.GTNewHorizons:Irontanks:1.4.0:dev")
+    api("com.github.GTNewHorizons:Irontanks:1.4.1:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.38-GTNH:dev")
 
     implementation("com.github.GTNewHorizons:Railcraft:9.16.13") {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@ dependencies {
     api("com.github.GTNewHorizons:Irontanks:1.4.1:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.7.38-GTNH:dev")
 
-    implementation("com.github.GTNewHorizons:Railcraft:9.16.16-pre:dev") {
+    implementation("com.github.GTNewHorizons:Railcraft:9.16.16:dev") {
         transitive = false
     }
 }

--- a/src/main/java/secondderivative/irontankminecarts/minecarts/EntityMinecartTankAbstract.java
+++ b/src/main/java/secondderivative/irontankminecarts/minecarts/EntityMinecartTankAbstract.java
@@ -3,11 +3,9 @@ package secondderivative.irontankminecarts.minecarts;
 import java.util.HashMap;
 import java.util.Map;
 
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidContainerRegistry;
 

--- a/src/main/java/secondderivative/irontankminecarts/minecarts/EntityMinecartTankAbstract.java
+++ b/src/main/java/secondderivative/irontankminecarts/minecarts/EntityMinecartTankAbstract.java
@@ -13,7 +13,6 @@ import net.minecraftforge.fluids.FluidContainerRegistry;
 
 import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.ClassPath.ClassInfo;
-import com.indemnity83.irontank.item.ItemTankChanger;
 import com.indemnity83.irontank.reference.TankType;
 
 import cpw.mods.fml.common.registry.EntityRegistry;
@@ -49,7 +48,7 @@ public abstract class EntityMinecartTankAbstract extends EntityCartTank {
                 if (EntityMinecartTankAbstract.class.isAssignableFrom(clazz)) {
                     Class<? extends EntityMinecartTankAbstract> cartClass = (Class<? extends EntityMinecartTankAbstract>) clazz;
                     TankType type = ((EntityMinecartTankAbstract) cartClass.getConstructor(World.class)
-                        .newInstance((World) null)).type();
+                        .newInstance((World) null)).tankType();
                     String rawname = IronTankMinecarts.tankTypeName(type);
                     EntityRegistry.registerModEntity(
                         cartClass,
@@ -68,7 +67,7 @@ public abstract class EntityMinecartTankAbstract extends EntityCartTank {
     }
 
     public ItemStack getCartItem() {
-        Item minecart = IronTankMinecarts.carts.get(type());
+        Item minecart = IronTankMinecarts.carts.get(tankType());
         return new ItemStack(minecart != null ? minecart : Items.minecart);
     }
 
@@ -79,38 +78,6 @@ public abstract class EntityMinecartTankAbstract extends EntityCartTank {
                 .newInstance(world, x, y, z);
         } catch (Exception e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    public abstract TankType type();
-
-    @Override
-    public boolean doInteract(EntityPlayer player) {
-        ItemStack stack = player.getCurrentEquippedItem();
-        if (stack != null && stack.getItem() instanceof ItemTankChanger changer) {
-            if (changer.type.canUpgrade(type())) {
-                if (!worldObj.isRemote) {
-                    TankType newType = changer.type.target;
-                    NBTTagCompound nbt = new NBTTagCompound();
-                    writeToNBT(nbt);
-                    setDead();
-                    try {
-                        EntityMinecartTankAbstract minecart = map.get(newType)
-                            .getConstructor(World.class)
-                            .newInstance(worldObj);
-                        minecart.readFromNBT(nbt);
-                        worldObj.spawnEntityInWorld(minecart);
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
-                if (!player.capabilities.isCreativeMode && --stack.stackSize <= 0) {
-                    player.setCurrentItemOrArmor(0, null);
-                }
-            }
-            return true;
-        } else {
-            return super.doInteract(player);
         }
     }
 }

--- a/src/main/java/secondderivative/irontankminecarts/minecarts/EntityMinecartTankAbstract.java
+++ b/src/main/java/secondderivative/irontankminecarts/minecarts/EntityMinecartTankAbstract.java
@@ -23,7 +23,7 @@ import secondderivative.irontankminecarts.IronTankMinecarts;
 
 public abstract class EntityMinecartTankAbstract extends EntityCartTank {
 
-    private static final Map<TankType, Class<? extends EntityMinecartTankAbstract>> map = new HashMap<TankType, Class<? extends EntityMinecartTankAbstract>>();
+    public static final Map<TankType, Class<? extends EntityMinecartTankAbstract>> map = new HashMap<TankType, Class<? extends EntityMinecartTankAbstract>>();
 
     public EntityMinecartTankAbstract(World world, TankType type) {
         super(world);

--- a/src/main/java/secondderivative/irontankminecarts/minecarts/EntityMinecartTankAbstract.java
+++ b/src/main/java/secondderivative/irontankminecarts/minecarts/EntityMinecartTankAbstract.java
@@ -3,14 +3,17 @@ package secondderivative.irontankminecarts.minecarts;
 import java.util.HashMap;
 import java.util.Map;
 
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidContainerRegistry;
 
 import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.ClassPath.ClassInfo;
+import com.indemnity83.irontank.item.ItemTankChanger;
 import com.indemnity83.irontank.reference.TankType;
 
 import cpw.mods.fml.common.registry.EntityRegistry;
@@ -80,4 +83,34 @@ public abstract class EntityMinecartTankAbstract extends EntityCartTank {
     }
 
     public abstract TankType type();
+
+    @Override
+    public boolean doInteract(EntityPlayer player) {
+        ItemStack stack = player.getCurrentEquippedItem();
+        if (stack != null && stack.getItem() instanceof ItemTankChanger changer) {
+            if (changer.type.canUpgrade(type())) {
+                if (!worldObj.isRemote) {
+                    TankType newType = changer.type.target;
+                    NBTTagCompound nbt = new NBTTagCompound();
+                    writeToNBT(nbt);
+                    setDead();
+                    try {
+                        EntityMinecartTankAbstract minecart = map.get(newType)
+                            .getConstructor(World.class)
+                            .newInstance(worldObj);
+                        minecart.readFromNBT(nbt);
+                        worldObj.spawnEntityInWorld(minecart);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+                if (!player.capabilities.isCreativeMode && --stack.stackSize <= 0) {
+                    player.setCurrentItemOrArmor(0, null);
+                }
+            }
+            return true;
+        } else {
+            return super.doInteract(player);
+        }
+    }
 }

--- a/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartAluminiumTank.java
+++ b/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartAluminiumTank.java
@@ -19,7 +19,7 @@ public class EntityMinecartAluminiumTank extends EntityMinecartTankAbstract {
     }
 
     @Override
-    public TankType type() {
+    public TankType tankType() {
         return type;
     }
 

--- a/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartCopperTank.java
+++ b/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartCopperTank.java
@@ -19,7 +19,7 @@ public class EntityMinecartCopperTank extends EntityMinecartTankAbstract {
     }
 
     @Override
-    public TankType type() {
+    public TankType tankType() {
         return type;
     }
 

--- a/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartDiamondTank.java
+++ b/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartDiamondTank.java
@@ -19,7 +19,7 @@ public class EntityMinecartDiamondTank extends EntityMinecartTankAbstract {
     }
 
     @Override
-    public TankType type() {
+    public TankType tankType() {
         return type;
     }
 

--- a/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartGoldTank.java
+++ b/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartGoldTank.java
@@ -19,7 +19,7 @@ public class EntityMinecartGoldTank extends EntityMinecartTankAbstract {
     }
 
     @Override
-    public TankType type() {
+    public TankType tankType() {
         return type;
     }
 

--- a/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartIronTank.java
+++ b/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartIronTank.java
@@ -19,7 +19,7 @@ public class EntityMinecartIronTank extends EntityMinecartTankAbstract {
     }
 
     @Override
-    public TankType type() {
+    public TankType tankType() {
         return type;
     }
 

--- a/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartStainlessSteelTank.java
+++ b/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartStainlessSteelTank.java
@@ -19,7 +19,7 @@ public class EntityMinecartStainlessSteelTank extends EntityMinecartTankAbstract
     }
 
     @Override
-    public TankType type() {
+    public TankType tankType() {
         return type;
     }
 

--- a/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartSteelTank.java
+++ b/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartSteelTank.java
@@ -19,7 +19,7 @@ public class EntityMinecartSteelTank extends EntityMinecartTankAbstract {
     }
 
     @Override
-    public TankType type() {
+    public TankType tankType() {
         return type;
     }
 

--- a/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartTitaniumTank.java
+++ b/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartTitaniumTank.java
@@ -19,7 +19,7 @@ public class EntityMinecartTitaniumTank extends EntityMinecartTankAbstract {
     }
 
     @Override
-    public TankType type() {
+    public TankType tankType() {
         return type;
     }
 

--- a/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartTungstensteelTank.java
+++ b/src/main/java/secondderivative/irontankminecarts/minecarts/types/EntityMinecartTungstensteelTank.java
@@ -19,7 +19,7 @@ public class EntityMinecartTungstensteelTank extends EntityMinecartTankAbstract 
     }
 
     @Override
-    public TankType type() {
+    public TankType tankType() {
         return type;
     }
 


### PR DESCRIPTION
the vanilla railcraft cart must be done on the Railcraft side

irontanks dependency broken intentionally because a bugfix on irontanks is needed

Requires a new release with https://github.com/GTNewHorizons/Irontanks/pull/14 merged

also requires https://github.com/GTNewHorizons/Railcraft/pull/83